### PR TITLE
Restore the ability to have visible DataTable footers

### DIFF
--- a/css/scss/style.scss
+++ b/css/scss/style.scss
@@ -1032,9 +1032,6 @@ body.login-page {
     }
   }
 
-  tfoot {
-    display: none;
-  }
 }
 
 .code-preview {

--- a/css/style.css
+++ b/css/style.css
@@ -652,9 +652,6 @@ body.login-page {
 .dataTables_wrapper .dataTables_paginate .paginate_button:hover, .dataTables_wrapper .dataTables_paginate .paginate_button.disabled, .dataTables_wrapper .dataTables_paginate .paginate_button.disabled:hover, .dataTables_wrapper .dataTables_paginate .paginate_button.disabled:active {
   border: 0; }
 
-.dataTables_wrapper tfoot {
-  display: none; }
-
 .code-preview {
   width: 100%;
   min-height: 400px; }

--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -652,9 +652,6 @@ body.login-page {
 .dataTables_wrapper .dataTables_paginate .paginate_button:hover, .dataTables_wrapper .dataTables_paginate .paginate_button.disabled, .dataTables_wrapper .dataTables_paginate .paginate_button.disabled:hover, .dataTables_wrapper .dataTables_paginate .paginate_button.disabled:active {
   border: 0; }
 
-.dataTables_wrapper tfoot {
-  display: none; }
-
 .code-preview {
   width: 100%;
   min-height: 400px; }

--- a/dist/html/table/datatable.html
+++ b/dist/html/table/datatable.html
@@ -278,16 +278,6 @@
                                                 <th>Salary</th>
                                             </tr>
                                         </thead>
-                                        <tfoot>
-                                            <tr>
-                                                <th>Name</th>
-                                                <th>Position</th>
-                                                <th>Office</th>
-                                                <th>Age</th>
-                                                <th>Start date</th>
-                                                <th>Salary</th>
-                                            </tr>
-                                        </tfoot>
                                         <tbody>
                                             <tr>
                                                 <td>Tiger Nixon</td>

--- a/html/table/datatable.html
+++ b/html/table/datatable.html
@@ -278,16 +278,6 @@
                                                 <th>Salary</th>
                                             </tr>
                                         </thead>
-                                        <tfoot>
-                                            <tr>
-                                                <th>Name</th>
-                                                <th>Position</th>
-                                                <th>Office</th>
-                                                <th>Age</th>
-                                                <th>Start date</th>
-                                                <th>Salary</th>
-                                            </tr>
-                                        </tfoot>
                                         <tbody>
                                             <tr>
                                                 <td>Tiger Nixon</td>


### PR DESCRIPTION
By default, all [DataTable](https://datatables.net) tfoot elements are hidden with display:none. This is rather heavy-handed and removes a major customization option from a powerful library. For an example of useful footers in DataTables, see [here](https://datatables.net/examples/api/multi_filter.html).

This PR simply removes the offending CSS rule and also removes the tfoot from the example datatable in the HTML docs, in order to preserve the look of Flat-Admin