### PR TITLE
Add style in the select element

### DIFF
--- a/src/elements/form/form.sass
+++ b/src/elements/form/form.sass
@@ -4,7 +4,7 @@
       border-color: $border-color
       box-shadow: none
 
-input, textarea
+input, textarea, select
   &.form-control
     border-radius: 2px
     padding: 10px 15px


### PR DESCRIPTION
If use select element in a form with the theme, it may cause problems because the "select" doesn't have a flat-admin style. I added the select in the "form-control" styles and it worked great.